### PR TITLE
[Forge 1.18.1] Debug & Thread safety

### DIFF
--- a/src/main/java/momo/grounded_origins/configuration/CubeCheckConfiguration.java
+++ b/src/main/java/momo/grounded_origins/configuration/CubeCheckConfiguration.java
@@ -6,7 +6,6 @@ import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import io.github.edwinmindcraft.apoli.api.IDynamicFeatureConfiguration;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 
@@ -14,7 +13,7 @@ import java.util.List;
 
 public record CubeCheckConfiguration(int radius, List<Entry> entries,
 									 int tickInterval) implements IDynamicFeatureConfiguration {
-	public record Entry(String name, TagKey tag, Comparison comparison, int compareTo) {}
+	public record Entry(String name, TagKey<Block> tag, Comparison comparison, int compareTo) {}
 
 	public static final SerializableDataType<Entry> ENTRY = SerializableDataType.compound(Entry.class, new SerializableData()
 					.add("name", SerializableDataTypes.STRING)

--- a/src/main/java/momo/grounded_origins/power/CubeCheckPowerForge.java
+++ b/src/main/java/momo/grounded_origins/power/CubeCheckPowerForge.java
@@ -1,7 +1,9 @@
 package momo.grounded_origins.power;
 
+import io.github.apace100.origins.Origins;
 import io.github.edwinmindcraft.apoli.api.power.configuration.ConfiguredPower;
 import io.github.edwinmindcraft.apoli.api.power.factory.PowerFactory;
+import io.github.edwinmindcraft.calio.common.CalioConfig;
 import momo.grounded_origins.configuration.CubeCheckCache;
 import momo.grounded_origins.configuration.CubeCheckConfiguration;
 import net.minecraft.core.BlockPos;
@@ -27,6 +29,8 @@ public class CubeCheckPowerForge extends PowerFactory<CubeCheckConfiguration> {
 	@Override
 	public void tick(@NotNull ConfiguredPower<CubeCheckConfiguration, ?> configuration, @NotNull Entity entity) {
 		this.getCache(configuration, entity).updateCache(entity.getLevel(), entity.blockPosition());
+		if (CalioConfig.COMMON.logging.get())
+			Origins.LOGGER.info(this.getCache(configuration, entity));
 	}
 
 	public void invalidate(@NotNull ConfiguredPower<CubeCheckConfiguration, ?> configuration, @NotNull Entity entity, BlockPos pos) {


### PR DESCRIPTION
Added debug code when `debug.registry_logging` is set to `true` in calio's common config.
Added thread safety to avoid CMEs and sets not being properly added to or cleared.